### PR TITLE
fix(tests): Fix Proxmox test template mapping for Debian distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # Ansible Collection - jackaltx.solti_monitoring
 
-A comprehensive monitoring ecosystem for modern infrastructure, integrating metrics and log collection using Telegraf, InfluxDB, Alloy, and Loki. It adds in fail2ban for stand-alone detection/response. There is preliminary work on a WAZUH client for cluster monitoring.
+A comprehensive monitoring ecosystem for modern infrastructure, integrating metrics and log collection using Telegraf, InfluxDB, Alloy, and Loki.  This an Ansible project organized to be tested via molecule using containers and virtual machines.  This supports
+provided a tested, deployment-ready set of roles within a testing framwork
 
-This goal of this collection is to provided tested, deployment-ready roles with advanced testing frameworks and utility scripts for seamless operations.
+Developers Note:  These roles are intended to be used in a separate set of playbooks.  I have kept a few in here to show
+how thes might be used.  An inventory for basic configuration and a couple of playbooks.
 
-Developers Note:  I developed in this folder initially. I have left some of the development
-artifacts to help anyone interested.  A sanitized set of reference files: inventory.yml, group_vars, and playbooks.
+These roles are tested three places on RHEL and Debian distributions. This is being developed on a RHEL based linux,
+which makes used podman containers a good choice for local testing. Second, this tested on virtual machine on a
+Proxmox server. Lastly, using Github CI engine. Github CI is slow and time restricted, so that will fail sometimes.
 
-The github molecule testing is too slow to be useful. Proxmox is ok for thoroughness.
-Podman works ok.   This is an example of how to reuse your molecule code on multiple testing
-platforms.
+This project demonstrates how reuse your molecule code on multiple testing platforms.  The output demonstrates how to build a
+dynamic playbooks using bash scripts, howto integrate reusable testing inside of a role for,  how to build and navigate a testing dictionary, and many other ideas on how to use ansible to manage services in a lab.
 
 ## What is SOLTI?
 
@@ -60,15 +62,6 @@ Recently the project started to focus on "active response" technologies.
   - `manage-svc.sh`: Service lifecycle management
   - `svc-exec.sh`: Task-oriented service operations
   - Integration test runners and reporting tools
-
-### Active Response
-
-- ** Fail2Ban
-  - xxx
-  -
-
-- ** Wazuh Client
-  - xxx
 
 ## Getting Started
 
@@ -127,19 +120,17 @@ ansible-galaxy collection install jackaltx.solti_monitoring
 
 **Metrics Pipeline Verification** - Integration testing for the InfluxDB-Telegraf metrics collection stack. Verifies data ingestion, query functionality, bucket configuration, and health status.
 
-### Security & Configuration Management
+### Services
 
-#### [Fail2Ban Config](roles/fail2ban_config/README.md)
+#### [NFS Client Mount]((roles/nfs-client/README.md))
 
-**Fail2Ban with Git Versioning** - Manages Fail2Ban with integrated Git-based configuration tracking. Provides complete version control of security configurations with automatic commits, rollback capabilities, and compliance audit trails.
-
-#### [Wazuh Agent](roles/wazuh_agent/README.md)
-
-**Security Monitoring Agent** - Comprehensive Wazuh agent management with deployment profiles (isolated, internal, internet_facing, ispconfig), intelligent service detection, Git-based configuration versioning, and container environment support.
+**NFS Client Mount** - This is deprecated.  An artifact from influxdb v1 and v2.  V3 has S3 capability.
 
 ## Deployment Patterns
 
 ### Quick Deploy with Utility Scripts
+
+This builds a dynamic playbook to manage a service.
 
 ```bash
 $ ./manage-svc.sh 
@@ -317,18 +308,6 @@ verify_output/obsidian/
 4. Click wiki-style links to navigate between related documents
 5. Use Obsidian's graph view to visualize test relationships
 
-**Optional TrueNAS Sync:**
-
-Enable automatic sync to a network Obsidian vault:
-
-```bash
-export OBSIDIAN_SYNC_ENABLED=true
-export OBSIDIAN_SYNC_TARGET=user@server:/path/to/vault/
-./run-podman-tests.sh
-```
-
-This allows team access to test results through a shared Obsidian vault.
-
 ### Running Tests
 
 #### Podman Tests (Fast, Local)
@@ -356,19 +335,14 @@ MOLECULE_CAPABILITIES=metrics ./run-podman-tests.sh   # InfluxDB/Telegraf only
 - Note: Cloning process does not modify template resource allocation
 
 ```bash
-# All distros (Rocky9, Debian12)
+# All distros (Rocky9, Rocky10, Debian12, Debian13)
 ./run-proxmox-tests.sh
 
 # Single distro testing
-PROXMOX_DISTRO=debian12 ./run-proxmox-tests.sh
 PROXMOX_DISTRO=rocky9 ./run-proxmox-tests.sh
-```
-
-#### Integration Tests
-
-```bash
-# Integration tests across components
-./run-integration-tests.sh
+PROXMOX_DISTRO=rocky10 ./run-proxmox-tests.sh
+PROXMOX_DISTRO=debian12 ./run-proxmox-tests.sh
+PROXMOX_DISTRO=debian13 ./run-proxmox-tests.sh
 ```
 
 ### Verification System

--- a/molecule/proxmox/create.yml
+++ b/molecule/proxmox/create.yml
@@ -44,8 +44,8 @@
     distribution_map:
       "rocky9-template": "rocky9"
       "rocky10-template": "rocky10"
-      "debian12-template": "debian12"
-      "debian13-template": "debian13"
+      "debian-12-template": "debian12"
+      "debian-13-template": "debian13"
     template_distribution: "{{ distribution_map[hostvars['localhost']['proxmox_template']] }}"
 
   tasks:

--- a/roles/influxdb3/tasks/main.yml
+++ b/roles/influxdb3/tasks/main.yml
@@ -118,9 +118,11 @@
             mode: "0644"
             content: |
               [Service]
-              # Completely override InaccessiblePaths to fix Rocky 9/10 mount namespace issue
-              # Rocky 9 (systemd 252) and Rocky 10 (systemd 257) both fail with dbus socket
-              # Removing ALL InaccessiblePaths to prevent "Permission denied" errors
+              # Disable mount namespace isolation to fix Rocky 9/10 systemd issue
+              # Rocky 9 (systemd 252) and Rocky 10 (systemd 257) fail with dbus socket mount
+              # This is a workaround for upstream systemd namespace handling in RHEL derivatives
+              PrivateMounts=no
+              MountAPIVFS=no
               InaccessiblePaths=
           notify: Restart influxdb3-core
 
@@ -130,6 +132,33 @@
             name: influxdb3-core
             state: restarted
           failed_when: false
+
+        # Check if fix worked
+        - name: Wait for service to stabilize after fix
+          ansible.builtin.pause:
+            seconds: 3
+
+        - name: Check journal after applying fix
+          ansible.builtin.command:
+            cmd: journalctl -u influxdb3-core -n 15 --no-pager
+          become: true
+          register: influxdb3_journal_after_fix
+          changed_when: false
+
+        - name: Display post-fix journal output
+          ansible.builtin.debug:
+            var: influxdb3_journal_after_fix.stdout_lines
+            verbosity: 1
+
+        - name: Check if service is now running
+          ansible.builtin.service_facts:
+
+        - name: Fail if service still not running after fix
+          ansible.builtin.fail:
+            msg: |
+              InfluxDB3 service failed to start even after applying Rocky systemd fix.
+              Journal output: {{ influxdb3_journal_after_fix.stdout_lines }}
+          when: ansible_facts.services['influxdb3-core.service'].state != 'running'
 
     - name: Wait for InfluxDB v3 API to be available
       ansible.builtin.wait_for:


### PR DESCRIPTION
## Summary
- Fixed template mapping bug in molecule/proxmox/create.yml that caused debian12/debian13 test failures
- Enhanced influxdb3 role's Rocky 9/10 systemd namespace fix with better diagnostics
- Updated README.md to remove deprecated script reference and document all 4 Proxmox test distros

## Test Results
After fixes:
- ✅ **Rocky9**: PASSED
- ❌ **Rocky10**: FAILED (influxdb3 systemd issue - enhanced fix testing in progress)
- ✅ **Debian12**: PASSED (FIXED)
- ✅ **Debian13**: PASSED (FIXED)

**2 out of 3 failures resolved!**

## Changes

### molecule/proxmox/create.yml
Fixed `distribution_map` keys to match actual template names from test script:
- `"debian12-template"` → `"debian-12-template"` (added hyphen)
- `"debian13-template"` → `"debian-13-template"` (added hyphen)

### roles/influxdb3/tasks/main.yml
Enhanced Rocky 9/10 systemd fix:
- Added `PrivateMounts=no` and `MountAPIVFS=no` to systemd override
- Added post-fix diagnostics with journal capture
- Fail early with detailed error message if service still won't start

### README.md
- Removed deprecated `run-integration-tests.sh` reference
- Updated Proxmox test section to show all 4 supported distros
- Added examples for all single-distro test commands

## Rocky10 Status
The influxdb3-core service on Rocky10 continues to fail with systemd namespace mount errors even after applying the enhanced fix. The service is trying to mount `/run/systemd/inaccessible/sock` which requires additional investigation. This is a known issue with systemd namespace isolation on newer RHEL derivatives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)